### PR TITLE
Dockerize Scraper Service

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -1,0 +1,38 @@
+version: '3.8'
+
+services:
+  
+  scraper-db:
+    image: mongo:latest
+    container_name: scraper-db
+    restart: unless-stopped
+    # volumes not needed for now
+    # volumes:
+      # - scraper-data:/data/db
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: root
+
+  mongo-express:
+    image: mongo-express
+    container_name: mongo-express
+    restart: unless-stopped
+    ports:
+      - 8081:8081
+    environment:
+      ME_CONFIG_MONGODB_ADMINUSERNAME: root
+      ME_CONFIG_MONGODB_ADMINPASSWORD: root
+      ME_CONFIG_MONGODB_URL: mongodb://root:root@scraper-db:27017
+    depends_on:
+      - "scraper-db"
+  
+   
+  scraper:
+    build:
+      context: ./scraper_service
+    environment:
+      - MONGO_URI=mongodb://root:root@scraper-db:27017
+      - MONGO_DATABASE=scraper
+    restart: unless-stopped
+    depends_on:
+      - "scraper-db"

--- a/services/scraper_service/.dockerignore
+++ b/services/scraper_service/.dockerignore
@@ -1,0 +1,1 @@
+Pipfile*

--- a/services/scraper_service/Dockerfile
+++ b/services/scraper_service/Dockerfile
@@ -1,7 +1,14 @@
 FROM tred7/scrapyd:latest
 
+RUN set -ex \
+    && apt-get update \
+    && apt-get install -y dos2unix \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 ENV MONGO_URI=
 ENV MONGO_DATABASE=
+ENV MODE=
 
 WORKDIR /usr/project/
 
@@ -11,13 +18,10 @@ RUN pip install -r requirements.txt
 
 COPY . .
 
-RUN \
-    chmod 0644 schedule.cronjob \
-    && crontab schedule.cronjob \
+RUN dos2unix crontab.* *.sh jobs/*.* \
+    && \
+    find . -type f -iname "*.sh" -exec chmod +x {} \; \
+    && find . -type f -iname "crontab.*" -exec chmod 0644 {} \; \
     && touch /var/log/cron.log
 
-WORKDIR /usr/project/news_scraper
-
-CMD scrapyd-deploy \
-        && (cron -f &) \
-        && tail -f /var/log/journal/scrapyd.service.log
+CMD ["./start.sh"]

--- a/services/scraper_service/Dockerfile
+++ b/services/scraper_service/Dockerfile
@@ -1,0 +1,23 @@
+FROM tred7/scrapyd:latest
+
+ENV MONGO_URI=
+ENV MONGO_DATABASE=
+
+WORKDIR /usr/project/
+
+COPY requirements.txt ./requirements.txt
+
+RUN pip install -r requirements.txt
+
+COPY . .
+
+RUN \
+    chmod 0644 schedule.cronjob \
+    && crontab schedule.cronjob \
+    && touch /var/log/cron.log
+
+WORKDIR /usr/project/news_scraper
+
+CMD scrapyd-deploy \
+        && (cron -f &) \
+        && tail -f /var/log/journal/scrapyd.service.log

--- a/services/scraper_service/crontab.Development
+++ b/services/scraper_service/crontab.Development
@@ -1,0 +1,2 @@
+PATH="/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+0-59/2 * * * * /usr/project/jobs/schedule_spiders.sh 2>&1 | tee -a /var/log/cron.log

--- a/services/scraper_service/crontab.Production
+++ b/services/scraper_service/crontab.Production
@@ -1,0 +1,2 @@
+PATH="/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+0 0-23/6 * * * cd /usr/project/news_scraper && scrapyd-client schedule -p news_scraper \* >> /var/log/cron.log 2>&1

--- a/services/scraper_service/jobs/schedule_spiders.sh
+++ b/services/scraper_service/jobs/schedule_spiders.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -ex
+echo "Scheduling spiders..."
+cd /usr/project/news_scraper \
+    && scrapyd-client schedule -p news_scraper \*

--- a/services/scraper_service/news_scraper/scrapy.cfg
+++ b/services/scraper_service/news_scraper/scrapy.cfg
@@ -7,5 +7,5 @@
 default = news_scraper.settings
 
 [deploy]
-#url = http://localhost:6800/
+url = http://localhost:6800/
 project = news_scraper

--- a/services/scraper_service/schedule.cronjob
+++ b/services/scraper_service/schedule.cronjob
@@ -1,2 +1,0 @@
-PATH="/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-0 0-23/2 * * * cd /usr/project/news_scraper && scrapyd-client schedule -p news_scraper \* >> /var/log/cron.log 2>&1

--- a/services/scraper_service/schedule.cronjob
+++ b/services/scraper_service/schedule.cronjob
@@ -1,0 +1,2 @@
+PATH="/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+0 0-23/2 * * * cd /usr/project/news_scraper && scrapyd-client schedule -p news_scraper \* >> /var/log/cron.log 2>&1

--- a/services/scraper_service/start.sh
+++ b/services/scraper_service/start.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -ex
+
 cd /usr/project/news_scraper
 
 scrapyd-deploy

--- a/services/scraper_service/start.sh
+++ b/services/scraper_service/start.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+cd /usr/project/news_scraper
+
+scrapyd-deploy
+
+cd /usr/project
+
+if [ -z "$MODE"]; then
+    echo "MODE not set, assuming Development"
+    MODE="Development"
+fi
+
+CRON_FILE="crontab.$MODE"
+
+echo "Loading crontab from $CRON_FILE"
+
+crontab $CRON_FILE
+
+echo "Starting cron"
+
+cron -f


### PR DESCRIPTION
Everyone log please test it on your system. Is it working?

## To run the Scraper Service follow these steps : 

- Switch to the `services` directory and run : 
   ```
   docker compose up --build
  ```
- If everything works, you can visit [localhost:8081](http://localhost:8081) to open the mongo-express.
- By default the spiders will run every 2 minutes for testing purposes.
- Check if the scraper database is formed in mongo-express and proper collections are created.
- If everything works don't forget to stop and remove the containers by first pressing `Ctrl-C` and then running `docker compose down`.
- Also to clean any volumes run `docker volume prune`

## Closes #24 